### PR TITLE
add explicit functions to import in __init__.py

### DIFF
--- a/traildb/__init__.py
+++ b/traildb/__init__.py
@@ -1,1 +1,1 @@
-from .traildb import TrailDBError, TrailDBConstructor, TrailDB, TrailDBCursor
+from .traildb import TrailDBError, TrailDBConstructor, TrailDB, TrailDBCursor, tdb_item_field, tdb_item_val


### PR DESCRIPTION
fixes a bug where `tdb_item_field` and `tdb_item_value` cannot be found and cause import errors.
