### PR TITLE
fix error message & minimal travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+    - 2.7
+
+script:
+    - ./runtests.sh
+
+before_install:
+    - sudo apt-get -y install libarchive-dev libjudy-dev pkg-config
+    - ./travisdeps.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+appdirs==1.4.3
+configparser==3.5.0
+enum34==1.1.6
+flake8==3.3.0
+mccabe==0.6.1
+packaging==16.8
+pycodestyle==2.3.1
+pyflakes==1.5.0
+pyparsing==2.2.0
+six==1.10.0

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib"
+
+set -e
+
+# E999 -- syntax error
+# F821 -- undefined local variable
+flake8 ./traildb/ | grep '[ ]E999[ ]\|[ ]F821[ ]' | awk '{print} END {exit(NR > 0)}'
+
+env PYTHONPATH='.' python test/test.py

--- a/traildb/traildb.py
+++ b/traildb/traildb.py
@@ -178,7 +178,7 @@ class TrailDBConstructor(object):
         if f < 0:
             raise TrailDBError("Wrong number of fields: %d" % db.num_fields)
         if f > 0:
-            raise TrailDBError("Too many values: %s" % values[f])
+            raise TrailDBError("Too many values")
 
     def finalize(self):
         """Finalize this TrailDB. You cannot add new events in this TrailDB

--- a/travisdeps.sh
+++ b/travisdeps.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# compile dependency in /opt/traildb/traildb
+
+mkdir -p /opt/traildb
+cd /opt/traildb
+
+# shallow-ish copy of master branch of traildb/traildb
+git clone --depth=50 https://github.com/traildb/traildb
+
+# build traildb so
+cd /opt/traildb/traildb
+./waf configure
+# actually needs root permissions to install into /usr/local
+sudo ./waf install


### PR DESCRIPTION
`values` is not defined in the body of `append` method, remove from error message.

Minimal travis stuff to support Python 2.7 .