### PR TITLE
Add Multicursor Support

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -21,6 +21,9 @@ These are Python 2 bindings to TrailDB. Official TrailDB website is at http://tr
 .. autoclass:: traildb.TrailDBCursor
    :members:
 
+.. autoclass:: traildb.TrailDBMultiCursor
+   :members:
+
 .. autoclass:: traildb.TrailDBEventFilter
    :members:
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='traildb',
-      version='0.0.1',
+      version='0.0.2',
       description='TrailDB stores and queries cookie trails from raw logs.',
       author='AdRoll.com',
       install_requires=['future>=0.16.0'],

--- a/test/test.py
+++ b/test/test.py
@@ -410,10 +410,10 @@ class TestMultiCursor(unittest.TestCase):
         cons.add(self.uuid1, 5, ['e', '5', 'x', 'p'])
         self.tdb2 = cons.finalize()
 
-    def test_multicursor_no_batch(self):
+    def test_multicursor(self):
         c1 = self.tdb1.trail(self.tdb1.get_trail_id(self.uuid1))
         c2 = self.tdb2.trail(self.tdb2.get_trail_id(self.uuid1))
-        mc = TrailDBMultiCursor(False, False, False, batch_size=0)
+        mc = TrailDBMultiCursor(False, False, False)
 
         # not initialized, raise error
         with self.assertRaises(TrailDBError):
@@ -424,52 +424,26 @@ class TestMultiCursor(unittest.TestCase):
         events = list(mc)
 
         self.assertEqual(len(events), 5)
-        self.assertEqual(events[0].time, 1)
-        self.assertEqual(events[0].field1, 'a')
-        self.assertEqual(events[0].field2, '1')
-        self.assertEqual(events[0].field3, 'x')
-        self.assertEqual(events[1].time, 2)
-        self.assertEqual(events[1].field1, 'b')
-        self.assertEqual(events[1].field2, '2')
-        self.assertEqual(events[1].field3, 'x')
+        self.assertEqual(events[0][0].time, 1)
+        self.assertEqual(events[0][0].field1, 'a')
+        self.assertEqual(events[0][0].field2, '1')
+        self.assertEqual(events[0][0].field3, 'x')
+        self.assertEqual(events[1][0].time, 2)
+        self.assertEqual(events[1][0].field1, 'b')
+        self.assertEqual(events[1][0].field2, '2')
+        self.assertEqual(events[1][0].field3, 'x')
         # this one is from the 2nd tdb, has an additional field
-        self.assertEqual(events[2].time, 3)
-        self.assertEqual(events[2].field1, 'c')
-        self.assertEqual(events[2].field2, '3')
-        self.assertEqual(events[2].field3, 'y')
-        self.assertEqual(events[2].field4, 'n')
-
-    def test_multicursor_batch(self):
-        c1 = self.tdb1.trail(self.tdb1.get_trail_id(self.uuid1))
-        c2 = self.tdb2.trail(self.tdb2.get_trail_id(self.uuid1))
-
-        # test with a very small batch size to make sure the batch will get exhausted and refilled at least once
-        mc = TrailDBMultiCursor(False, False, False, batch_size=2)
-        mc.set_cursors([c1, c2], [self.tdb1, self.tdb2])
-
-        # exhaust the iterator
-        events = list(mc)
-
-        self.assertEqual(len(events), 5)
-        self.assertEqual(events[0].time, 1)
-        self.assertEqual(events[0].field1, 'a')
-        self.assertEqual(events[0].field2, '1')
-        self.assertEqual(events[0].field3, 'x')
-        self.assertEqual(events[1].time, 2)
-        self.assertEqual(events[1].field1, 'b')
-        self.assertEqual(events[1].field2, '2')
-        self.assertEqual(events[1].field3, 'x')
-        self.assertEqual(events[2].time, 3)
-        self.assertEqual(events[2].field1, 'c')
-        self.assertEqual(events[2].field2, '3')
-        self.assertEqual(events[2].field3, 'y')
-        self.assertEqual(events[2].field4, 'n')
+        self.assertEqual(events[2][0].time, 3)
+        self.assertEqual(events[2][0].field1, 'c')
+        self.assertEqual(events[2][0].field2, '3')
+        self.assertEqual(events[2][0].field3, 'y')
+        self.assertEqual(events[2][0].field4, 'n')
 
     def test_multicursor_reuse(self):
         c1 = self.tdb1.trail(self.tdb1.get_trail_id(self.uuid1))
         c2 = self.tdb2.trail(self.tdb2.get_trail_id(self.uuid1))
-        mc = TrailDBMultiCursor(False, False, False, batch_size=2)
-        mc.set_cursors([c1.cursor, c2.cursor], [self.tdb1, self.tdb2])
+        mc = TrailDBMultiCursor(False, False, False)
+        mc.set_cursors([c1, c2], [self.tdb1, self.tdb2])
         # exhaust the iterator
         list(mc)
 
@@ -482,20 +456,20 @@ class TestMultiCursor(unittest.TestCase):
         events = list(mc)
 
         self.assertEqual(len(events), 5)
-        self.assertEqual(events[0].time, 1)
-        self.assertEqual(events[0].field1, 'c')
-        self.assertEqual(events[0].field2, '3')
-        self.assertEqual(events[0].field3, 'y')
-        self.assertEqual(events[3].time, 4)
-        self.assertEqual(events[3].field1, 'a')
-        self.assertEqual(events[3].field2, '1')
-        self.assertEqual(events[3].field3, 'x')
-        self.assertEqual(events[3].field4, 'l')
+        self.assertEqual(events[0][0].time, 1)
+        self.assertEqual(events[0][0].field1, 'c')
+        self.assertEqual(events[0][0].field2, '3')
+        self.assertEqual(events[0][0].field3, 'y')
+        self.assertEqual(events[3][0].time, 4)
+        self.assertEqual(events[3][0].field1, 'a')
+        self.assertEqual(events[3][0].field2, '1')
+        self.assertEqual(events[3][0].field3, 'x')
+        self.assertEqual(events[3][0].field4, 'l')
 
     def test_multicursor_raw_items_parsetime(self):
         c1 = self.tdb1.trail(self.tdb1.get_trail_id(self.uuid1))
         c2 = self.tdb2.trail(self.tdb2.get_trail_id(self.uuid1))
-        mc = TrailDBMultiCursor(True, True, False, batch_size=0)
+        mc = TrailDBMultiCursor(True, True, False)
         mc.set_cursors([c1, c2], [self.tdb1, self.tdb2])
         # exhaust the iterator
         events = list(mc)

--- a/test/test.py
+++ b/test/test.py
@@ -443,7 +443,7 @@ class TestMultiCursor(unittest.TestCase):
         c1 = self.tdb1.trail(self.tdb1.get_trail_id(self.uuid1))
         c2 = self.tdb2.trail(self.tdb2.get_trail_id(self.uuid1))
 
-        # test with a very small batch size to make sure the batch will get exhausted and refilled at leat once
+        # test with a very small batch size to make sure the batch will get exhausted and refilled at least once
         mc = TrailDBMultiCursor(False, False, False, batch_size=2)
         mc.set_cursors([c1, c2], [self.tdb1, self.tdb2])
 
@@ -496,12 +496,7 @@ class TestMultiCursor(unittest.TestCase):
         c1 = self.tdb1.trail(self.tdb1.get_trail_id(self.uuid1))
         c2 = self.tdb2.trail(self.tdb2.get_trail_id(self.uuid1))
         mc = TrailDBMultiCursor(True, True, False, batch_size=0)
-
-        # not initialized, raise error
-        with self.assertRaises(TrailDBError):
-            next(mc)
         mc.set_cursors([c1, c2], [self.tdb1, self.tdb2])
-
         # exhaust the iterator
         events = list(mc)
 

--- a/traildb/__init__.py
+++ b/traildb/__init__.py
@@ -2,6 +2,7 @@ from .traildb import TrailDBError
 from .traildb import TrailDBConstructor
 from .traildb import TrailDB
 from .traildb import TrailDBCursor
+from .traildb import TrailDBMultiCursor
 from .traildb import TrailDBEventFilter
 from .traildb import tdb_item_field
 from .traildb import tdb_item_val

--- a/traildb/traildb.py
+++ b/traildb/traildb.py
@@ -432,7 +432,6 @@ class TrailDBMultiCursor(object):
         event = multi_event.tdb_event
         tdb_ptr = multi_event.tdb
 
-        breakpoint()
         timestamp = event.contents.timestamp
         if self.parsetime:
             timestamp = datetime.fromtimestamp(event.contents.timestamp)
@@ -469,6 +468,8 @@ class TrailDBMultiCursor(object):
         self._cursors = cursors
 
         self.multicursor = lib.tdb_multi_cursor_new(cursor_array, n_cursors)
+        if self.multicursor is None:
+            raise TrailDBError("Failed to allocate memory for multicursor")
         self.reset()
 
         # mapping of the traildb pointer to the TrailDB object

--- a/traildb/traildb.py
+++ b/traildb/traildb.py
@@ -50,12 +50,18 @@ tdb_item    = c_uint64
 tdb_cursor  = c_void_p
 tdb_error   = c_int
 tdb_event_filter = c_void_p
+tdb_multi_cursor = c_void_p
 
 
 class tdb_event(Structure):
     _fields_ = [("timestamp", c_uint64),
                 ("num_items", c_uint64),
                 ("items", POINTER(tdb_item))]
+
+class tdb_multi_event(Structure):
+    _fields_ = [("tdb", tdb),
+                ("tdb_event", POINTER(tdb_event)),
+                ("cursor_idx", c_uint64)]
 
 class tdb_opt_value(Union):
     _fields_ = [("ptr", c_void_p),
@@ -111,6 +117,12 @@ api(lib.tdb_get_trail, [tdb_cursor, c_uint64], tdb_error)
 api(lib.tdb_get_trail_length, [tdb_cursor], c_uint64)
 api(lib.tdb_cursor_set_event_filter, [tdb_cursor, tdb_event_filter], tdb_error)
 
+api(lib.tdb_multi_cursor_new, [POINTER(tdb_cursor), c_uint64], tdb_multi_cursor)
+api(lib.tdb_multi_cursor_free, [tdb_multi_cursor])
+api(lib.tdb_multi_cursor_reset, [tdb_multi_cursor])
+api(lib.tdb_multi_cursor_next, [tdb_multi_cursor], tdb_multi_event)
+api(lib.tdb_multi_cursor_next_batch, [tdb_multi_cursor, POINTER(tdb_multi_event), c_uint64])
+
 api(lib.tdb_event_filter_new, [], tdb_event_filter)
 api(lib.tdb_event_filter_add_term, [tdb_event_filter, tdb_item, c_int], tdb_error)
 api(lib.tdb_event_filter_add_time_range, [c_uint64, c_uint64], tdb_error)
@@ -121,6 +133,7 @@ api(lib.tdb_event_filter_free, [tdb_event_filter])
 
 api(lib.tdb_set_opt, [tdb, c_uint, tdb_opt_value], tdb_error)
 api(lib.tdb_set_trail_opt, [tdb, c_uint64, c_uint, tdb_opt_value], tdb_error)
+
 
 def uuid_hex(uuid):
     """
@@ -333,6 +346,148 @@ class TrailDBCursor(object):
         if self.event_filter_obj:
             if lib.tdb_cursor_set_event_filter(self.cursor, self.event_filter_obj.flt):
                 raise TrailDBError("cursor_set_event_filter failed")
+
+
+class TrailDBMultiCursor(object):
+    """
+    TrailDBMultiCursor iterates over the events of multiple trails,
+    merged together into a single trail with events sorted in the ascending
+    time order. The trails can be from different traildbs.
+
+    To use, initialize and then set the cursors using the set_cursors method.
+    To reuse a multicursor, set new trails on the underlying cursors and then
+    call TrailDBMultiCursor.reset(). If filtering, apply event filters to the underlying
+    cursors individually before setting them on the multicursor, or call reset after doing so
+    if already set.
+    """
+
+    def __init__(self, parsetime, rawitems, only_timestamp, batch_size=1000):
+        """
+        :param parsetime: If True, returns datetime objects instead of integer timestamps.
+        :param rawitems: Return raw integer items instead of stringified values. Using raw items is usually a bit more efficient than using string values.
+        :param only_timestamp: If True, only return timestamps, not event objects.
+        :param batch_size: max number of events to fetch at once (optimization - doesn't change iteration behavior)
+        """
+        self.parsetime = parsetime
+        self.rawitems = rawitems
+        self.only_timestamp = only_timestamp
+        self.batch_size = batch_size
+        self.multicursor = None
+        self._ready = False
+        self._init_batch()
+
+    def __del__(self):
+        if self.multicursor:
+            lib.tdb_multi_cursor_free(self.multicursor)
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """ return the next event in the combined trails, in ascending timestamp order """
+        if not self._ready:
+            raise TrailDBError("Multicursor not initialized, call set_cursors")
+
+        if self.batch_size:
+            # fetch another batch if the array of events has been exhausted
+            # this is also true for the first iteration, as both are 0
+            if self._batch_idx == self._current_batch_size:
+                n_events = self._next_batch()
+                if not n_events:
+                    raise StopIteration()
+                self._batch_idx = 0
+
+            # return the next event in the batch:
+            event = self.to_event(self._batch[self._batch_idx])
+            self._batch_idx += 1
+        else:
+            multi_event = lib.tdb_multi_cursor_next(self.multicursor)
+            if multi_event:
+                event = self.to_event(multi_event.contents)
+            else:
+                raise StopIteration()
+
+        return event
+
+    def _init_batch(self):
+        if self.batch_size:
+            self._batch = (tdb_multi_event * self.batch_size)()
+            self._batch_idx = 0
+            self._current_batch_size = 0
+        else:
+            self._batch = None
+            self._batch_idx = None
+            self._current_batch_size = None
+
+    def _next_batch(self):
+        n_events = lib.tdb_multi_cursor_next_batch(
+            self.multicursor,
+            self._batch,
+            self.batch_size,
+        )
+        self._current_batch_size = n_events
+        return n_events
+
+    def to_event(self, multi_event):
+        event = multi_event.tdb_event
+        tdb_ptr = multi_event.tdb
+
+        breakpoint()
+        timestamp = event.contents.timestamp
+        if self.parsetime:
+            timestamp = datetime.fromtimestamp(event.contents.timestamp)
+
+        if self.only_timestamp:
+            return timestamp
+
+        try:
+            traildb = self._traildbs[tdb_ptr]
+        except KeyError:
+            raise TrailDBError("TrailDBMultiCursor encountered a traildb that was not included in set_cursors")
+
+        address = addressof(event.contents.items)
+        items = (tdb_item * event.contents.num_items).from_address(address)
+
+        if self.rawitems:
+            return traildb._event_cls(False, timestamp, *items)
+        else:
+            return traildb._event_cls(True, timestamp, *items)
+
+    def set_cursors(self, cursors, traildbs):
+        """
+        configure this multicursor to merge the specified cursors. This is required before use.
+
+        :param cursors: list of TrailDBCursor instances to merge
+        :param traildbs: list of TrailDB instances from which the cursors were created (only needs to be specified once, even if there are multiple cursors from the same TrailDB)
+        """
+
+        n_cursors = len(cursors)
+        cursor_array = (tdb_cursor * n_cursors)(*[c.cursor for c in cursors])
+
+        # maintain references to these in python so they wont get garbage collected
+        self._cursor_arr = cursor_array
+        self._cursors = cursors
+
+        self.multicursor = lib.tdb_multi_cursor_new(cursor_array, n_cursors)
+        self.reset()
+
+        # mapping of the traildb pointer to the TrailDB object
+        # we need this to get the configured traildb in python since we get a pointer to the tdb from the multi event
+        self._traildbs = {tdb._db: tdb for tdb in traildbs}
+
+        self._ready = True
+
+    def reset(self):
+        """
+        reset the state of the multicursor to sync with the underlying cursors.
+        Used when resuing cursors. Also resets the state of the python object,
+        including any batched results.
+        """
+
+        if self.multicursor:
+            lib.tdb_multi_cursor_reset(self.multicursor)
+        self._batch_idx = 0
+        self._current_batch_size = 0
 
 
 def mk_event_class(fields, valuefun):
@@ -654,7 +809,7 @@ class TrailDB(object):
                         TDB_OPT_EVENT_FILTER,
                         value)
 
-        value = tdb_opt_value(ptr = all_filter)
+        value = tdb_opt_value(ptr=all_filter)
 
         for uuid in uuids:
             try:
@@ -679,7 +834,7 @@ class TrailDB(object):
                         TDB_OPT_EVENT_FILTER,
                         value)
 
-        value = tdb_opt_value(ptr = empty_filter)
+        value = tdb_opt_value(ptr=empty_filter)
         for uuid in uuids:
             try:
                 trail_id = self.get_trail_id(uuid)


### PR DESCRIPTION
Add basic multicursor support. Currently doesn't support the multicursor batch functionality. 

This also does a little cleanup, such as deleting a duplicate tests.